### PR TITLE
color of Recovered number changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "covid-19-tracker",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@material-ui/core": "^4.11.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^7.2.1",
-    "chart.js": "^2.9.3",
-    "leaflet": "^1.6.0",
-    "numeral": "^2.0.6",
-    "react": "^16.13.1",
-    "react-chartjs-2": "^2.9.0",
-    "react-dom": "^16.13.1",
-    "react-leaflet": "^2.8.0",
-    "react-scripts": "^4.0.3"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+    "name": "covid-19-tracker",
+    "version": "0.1.0",
+    "private": true,
+    "dependencies": {
+        "@material-ui/core": "^4.11.0",
+        "@testing-library/jest-dom": "^4.2.4",
+        "@testing-library/react": "^9.5.0",
+        "@testing-library/user-event": "^7.2.1",
+        "chart.js": "^2.9.3",
+        "leaflet": "^1.6.0",
+        "numeral": "^2.0.6",
+        "react": "^16.13.1",
+        "react-chartjs-2": "^2.9.0",
+        "react-dom": "^16.13.1",
+        "react-leaflet": "^2.8.0",
+        "react-scripts": "^4.0.3"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    },
+    "eslintConfig": {
+        "extends": "react-app"
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    }
 }

--- a/src/InfoBox.css
+++ b/src/InfoBox.css
@@ -1,34 +1,34 @@
 .infoBox {
-  flex: 1;
-  cursor: pointer;
+    flex: 1;
+    cursor: pointer;
 }
 
 .infoBox:not(:last-child) {
-  margin-right: 10px;
+    margin-right: 10px;
 }
 
 .infoBox--selected {
-  border-top: 10px solid greenyellow;
+    border-top: 10px solid greenyellow;
 }
 
 .infoBox--red {
-  border-color: red;
+    border-color: red;
 }
 
 .infoBox__cases--green {
-  color: lightgreen !important;
+    color: green !important;
 }
 
 .infoBox__cases {
-  color: #cc1034;
-  font-weight: 600;
-  font-size: 1.75rem;
-  margin-bottom: 0.5rem;
+    color: #cc1034;
+    font-weight: 600;
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
 }
 
 .infoBox__total {
-  color: #6c757d;
-  font-weight: 700 !important;
-  font-size: 0.8rem !important;
-  margin-top: 15px !important;
+    color: #6c757d;
+    font-weight: 700 !important;
+    font-size: 0.8rem !important;
+    margin-top: 15px !important;
 }


### PR DESCRIPTION
## Info
     number of positive covid-19 patients and recovered patients are given in light green color

## Description

   In the front page number of positive covid-19 patients and recovered patients are given in which number of positive patients are shown in dark red color so which can be visible first and number of recovered patients are shown by light green. I think I because of this fearful thinking can be develop in peoples mind. if you show recovered number with dark green, so people can recognize the recovered number first and can feel relief because human eye is more sensitive to green color therefor for positive indicator we use green color.
here are changes I made .
here are the changes From
![images (5)_2_2_2](https://user-images.githubusercontent.com/85214168/135600966-bdb03b29-e34d-44f4-83e5-d2389af97b87.png)
 To
![images (5)_2_2_2_2](https://user-images.githubusercontent.com/85214168/135601026-e721a854-7a13-456d-8056-3373ca79772e.png)

 